### PR TITLE
Fix 'Reorganize colors only'

### DIFF
--- a/tilequant/image_converter.py
+++ b/tilequant/image_converter.py
@@ -80,12 +80,13 @@ class Tilequant:
             f"The image height must be divisible by {tile_height}"
         )
         self._img = img.convert("RGBA").convert("RGBa")
-        self._transparent_color: tuple[int, int, int] | None = None
+        self._transparent_color: tuple[int, int, int, int] | None = None
         if transparent_color is not None:
             self._transparent_color = (
                 transparent_color[0],
                 transparent_color[1],
                 transparent_color[2],
+                255,
             )
         self.tile_width = tile_width
         self.tile_height = tile_height

--- a/tilequant/image_converter.py
+++ b/tilequant/image_converter.py
@@ -80,13 +80,12 @@ class Tilequant:
             f"The image height must be divisible by {tile_height}"
         )
         self._img = img.convert("RGBA").convert("RGBa")
-        self._transparent_color: tuple[int, int, int, int] | None = None
+        self._transparent_color: tuple[int, int, int] | None = None
         if transparent_color is not None:
             self._transparent_color = (
                 transparent_color[0],
                 transparent_color[1],
-                transparent_color[2],
-                255,
+                transparent_color[2]
             )
         self.tile_width = tile_width
         self.tile_height = tile_height

--- a/tilequant/image_converter.py
+++ b/tilequant/image_converter.py
@@ -85,7 +85,7 @@ class Tilequant:
             self._transparent_color = (
                 transparent_color[0],
                 transparent_color[1],
-                transparent_color[2]
+                transparent_color[2],
             )
         self.tile_width = tile_width
         self.tile_height = tile_height

--- a/tilequant/legacy/image_converter.py
+++ b/tilequant/legacy/image_converter.py
@@ -62,7 +62,11 @@ class ImageConverter:
         self._img = img.convert("RGB")
         self._tile_width = tile_width
         self._tile_height = tile_height
-        self._transparent_color = transparent_color
+        self._transparent_color = (
+            transparent_color[0],
+            transparent_color[1],
+            transparent_color[2],
+        )
         self._reset(0, 0, 0, NONE, 0, False, False)
 
     # noinspection PyAttributeOutsideInit

--- a/tilequant/legacy/image_converter.py
+++ b/tilequant/legacy/image_converter.py
@@ -437,10 +437,8 @@ class ImageConverter:
             # Fill rest of palette
             p = list(p)
             p.extend([(0, 0, 0)] * (self._colors_per_palette - len(p)))
-            for r, g, b in p:
-                cols.append(r)
-                cols.append(g)
-                cols.append(b)
+            for item in p:
+              cols.extend([item[0], item[1], item[2]])
         for i in range(processed_palette_count, self._num_palettes):
             cols += [0] * 3 * self._colors_per_palette
         im.putpalette(cols)

--- a/tilequant/legacy/image_converter.py
+++ b/tilequant/legacy/image_converter.py
@@ -438,7 +438,7 @@ class ImageConverter:
             p = list(p)
             p.extend([(0, 0, 0)] * (self._colors_per_palette - len(p)))
             for item in p:
-              cols.extend([item[0], item[1], item[2]])
+                cols.extend([item[0], item[1], item[2]])
         for i in range(processed_palette_count, self._num_palettes):
             cols += [0] * 3 * self._colors_per_palette
         im.putpalette(cols)


### PR DESCRIPTION
"Amends 'Reorganize colors only' to use raw indexing, fixing 'too many values to unpack (expected 3)' Also corrects an edge case with how transparent colors are handled."